### PR TITLE
ros2_0_galactic: configure device

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(
 	src/main.cpp
 	src/xdainterface.cpp
 	src/xdacallback.cpp
+  src/xdautils.cpp
 )
 
 add_custom_command(
@@ -76,6 +77,13 @@ if(BUILD_TESTING)
   # uncomment the line when this package is not in a git repo
   #set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
+  
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(xda_test src/xdautils.cpp src/xdautils_test.cpp)
+  target_include_directories(xda_test PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/xspublic>
+    $<INSTALL_INTERFACE:include>)
+
 endif()
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ add_executable(
 	src/main.cpp
 	src/xdainterface.cpp
 	src/xdacallback.cpp
-  src/xdautils.cpp
+	src/xdautils.cpp
 )
 
 add_custom_command(
@@ -79,11 +79,10 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
   
   find_package(ament_cmake_gtest REQUIRED)
-  ament_add_gtest(xda_test src/xdautils.cpp src/xdautils_test.cpp)
+  ament_add_gtest(xda_test src/xdautils.cpp test/xdautils_test.cpp)
   target_include_directories(xda_test PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/xspublic>
     $<INSTALL_INTERFACE:include>)
-
 endif()
 
 ament_package()

--- a/param/xsens_mti_node.yaml
+++ b/param/xsens_mti_node.yaml
@@ -50,3 +50,13 @@
         angular_velocity_stddev: [0.0, 0.0, 0.0] # [rad/s]
         orientation_stddev: [0.0, 0.0, 0.0] # [rad]
         magnetic_field_stddev: [0.0, 0.0, 0.0] # [Tesla]
+
+        # Configure the filter profile
+        # onboard_filter_profile: "Robust/VRU"
+
+        # Configure the output data
+        # output_configuration:
+        #     - "XDI_PacketCounter=65535"
+        #     - "XDI_SampleTimeFine=65535"
+        #     - "XDI_StatusWord=65535"
+        #     - "XDI_Quaternion=200"

--- a/param/xsens_mti_node.yaml
+++ b/param/xsens_mti_node.yaml
@@ -22,6 +22,10 @@
 
         publisher_queue_size: 5
 
+        # Configure the sensor to rotate its output using:
+        alignment_local_quat: [ 1.0, 0., 0., 0. ] # (identity)
+        alignment_sensor_quat: [ 1.0, 0., 0., 0. ] # (identity)
+
         # TF transform frame_id (default: imu_link), you may want to change it if you use multiple devices
         frame_id: "imu_link"
 

--- a/param/xsens_mti_node.yaml
+++ b/param/xsens_mti_node.yaml
@@ -8,6 +8,7 @@
         scan_for_devices: true
         port: "" # port name, e.g. '/dev/ttyUSB0'
         baudrate: 115200 # non necessary for some devices
+        # config_baudrate: 921600
 
         ## Connect only to specific device_id:
         ##  device_id = '077007EF' (uppercase hex string), returns with error if the device with ID is not found on the ports

--- a/src/xdainterface.cpp
+++ b/src/xdainterface.cpp
@@ -368,6 +368,42 @@ bool XdaInterface::configureDevice()
 		}
 	}
 
+	auto configureAlignmentQuat = [&](const std::string& name)
+	{
+		const auto frame = (name == "sensor") ? XAF_Sensor : XAF_Local;
+		const auto parameterName = (frame == XAF_Sensor) ? "alignment_sensor_quat" : "alignment_local_quat";
+
+		std::vector<XsReal> alignment_quat;
+		if (get_parameter(parameterName, alignment_quat) && !alignment_quat.empty())
+		{
+			RCLCPP_INFO(get_logger(), "Configuration alignment rotation for %s", parameterName);
+			const auto currentAlignmentQuat = m_device->alignmentRotationQuaternion(frame);
+			RCLCPP_INFO(get_logger(), " - current alignment quaternion for %s (%d): [%f %f %f %f]",
+				parameterName, frame, currentAlignmentQuat.w(), currentAlignmentQuat.x(),
+				currentAlignmentQuat.y(), currentAlignmentQuat.z());
+
+			const auto paramAlignmentQuat = XsQuaternion{alignment_quat[0], alignment_quat[1], alignment_quat[2], alignment_quat[3]};
+			if (!paramAlignmentQuat.isEqual(currentAlignmentQuat, 0.01))
+			{
+				RCLCPP_INFO(get_logger(), " - desired alignment quaternion for %s (%d): [%f %f %f %f]", parameterName, frame,
+					paramAlignmentQuat.w(), paramAlignmentQuat.x(), paramAlignmentQuat.y(), paramAlignmentQuat.z());
+				if (!m_device->setAlignmentRotationQuaternion(frame, paramAlignmentQuat))
+					return handleError("Could not configure alignment quaternion");
+			}
+			else
+			{
+				RCLCPP_INFO(get_logger(), " - actual and desired are near each other, no action taken");
+			}
+		}
+
+		return true;
+	};
+
+	if (!configureAlignmentQuat("local"))
+		return handleError("Could not set the local rotation matrix");
+	if (!configureAlignmentQuat("sensor"))
+		return handleError("Could not set the sensor rotation matrix");
+
 	return true;
 }
 
@@ -468,6 +504,8 @@ void XdaInterface::declareCommonParameters()
 	declare_parameter<std::string>("onboard_filter_profile", "");
 	declare_parameter<std::vector<std::string>>("output_configuration", std::vector<std::string>());
 	declare_parameter("config_baudrate", XsBaud::rateToNumeric(XBR_Invalid));
+	declare_parameter<std::vector<XsReal>>("alignment_local_quat", {1., 0., 0., 0.});
+	declare_parameter<std::vector<XsReal>>("alignment_sensor_quat", {1., 0., 0., 0.});
 
 	declare_parameter("enable_logging", false);
 	declare_parameter("log_file", "log.mtb");

--- a/src/xdainterface.h
+++ b/src/xdainterface.h
@@ -94,6 +94,7 @@ private:
 	void registerCallback(PacketCallback *cb);
 	bool handleError(std::string error);
 	void declareCommonParameters();
+	bool configureDevice();
 
 	XsControl *m_control;
 	XsDevice *m_device;

--- a/src/xdautils.cpp
+++ b/src/xdautils.cpp
@@ -1,0 +1,227 @@
+
+#include "xdautils.h"
+#include <map>
+#include <iostream>
+#include <sstream>
+
+std::string get_xs_data_identifier_name(XsDataIdentifier identifier)
+{
+    switch (identifier) {
+        case XDI_TemperatureGroup: return "XDI_TemperatureGroup";
+        case XDI_Temperature: return "XDI_Temperature";
+
+        case XDI_TimestampGroup: return "XDI_TimestampGroup";
+        case XDI_UtcTime: return "XDI_UtcTime";
+        case XDI_PacketCounter: return "XDI_PacketCounter";
+        case XDI_Itow: return "XDI_Itow";
+        case XDI_GnssAge: return "XDI_GnssAge";
+        case XDI_PressureAge: return "XDI_PressureAge";
+        case XDI_SampleTimeFine: return "XDI_SampleTimeFine";
+        case XDI_SampleTimeCoarse: return "XDI_SampleTimeCoarse";
+        case XDI_FrameRange: return "XDI_FrameRange";
+        case XDI_PacketCounter8: return "XDI_PacketCounter8";
+        case XDI_SampleTime64: return "XDI_SampleTime64";
+
+        case XDI_OrientationGroup: return "XDI_OrientationGroup";
+        case XDI_Quaternion: return "XDI_Quaternion";
+        case XDI_RotationMatrix: return "XDI_RotationMatrix";
+        case XDI_EulerAngles: return "XDI_EulerAngles";
+
+        case XDI_PressureGroup: return "XDI_PressureGroup";
+        case XDI_BaroPressure: return "XDI_BaroPressure";
+
+        case XDI_AccelerationGroup: return "XDI_AccelerationGroup";
+        case XDI_DeltaV: return "XDI_DeltaV";
+        case XDI_Acceleration: return "XDI_Acceleration";
+        case XDI_FreeAcceleration: return "XDI_FreeAcceleration";
+        case XDI_AccelerationHR: return "XDI_AccelerationHR";
+
+        case XDI_IndicationGroup: return "XDI_IndicationGroup";
+        case XDI_TriggerIn1: return "XDI_TriggerIn1";
+        case XDI_TriggerIn2: return "XDI_TriggerIn2";
+        case XDI_TriggerIn3: return "XDI_TriggerIn3";
+
+        case XDI_PositionGroup: return "XDI_PositionGroup";
+        case XDI_AltitudeMsl: return "XDI_AltitudeMsl";
+        case XDI_AltitudeEllipsoid: return "XDI_AltitudeEllipsoid";
+        case XDI_PositionEcef: return "XDI_PositionEcef";
+        case XDI_LatLon: return "XDI_LatLon";
+
+        case XDI_GnssGroup: return "XDI_GnssGroup";
+        case XDI_GnssPvtData: return "XDI_GnssPvtData";
+        case XDI_GnssSatInfo: return "XDI_GnssSatInfo";
+        case XDI_GnssPvtPulse: return "XDI_GnssPvtPulse";
+
+        case XDI_AngularVelocityGroup: return "XDI_AngularVelocityGroup";
+        case XDI_RateOfTurn: return "XDI_RateOfTurn";
+        case XDI_DeltaQ: return "XDI_DeltaQ";
+        case XDI_RateOfTurnHR: return "XDI_RateOfTurnHR";
+
+        case XDI_RawSensorGroup: return "XDI_RawSensorGroup";
+        case XDI_RawAccGyrMagTemp: return "XDI_RawAccGyrMagTemp";
+        case XDI_RawGyroTemp: return "XDI_RawGyroTemp";
+        case XDI_RawAcc: return "XDI_RawAcc";
+        case XDI_RawGyr: return "XDI_RawGyr";
+        case XDI_RawMag: return "XDI_RawMag";
+        case XDI_RawDeltaQ: return "XDI_RawDeltaQ";
+        case XDI_RawDeltaV: return "XDI_RawDeltaV";
+        case XDI_RawBlob: return "XDI_RawBlob";
+
+        case XDI_AnalogInGroup: return "XDI_AnalogInGroup";
+        case XDI_AnalogIn1: return "XDI_AnalogIn1";
+        case XDI_AnalogIn2: return "XDI_AnalogIn2";
+
+        case XDI_MagneticGroup: return "XDI_MagneticGroup";
+        case XDI_MagneticField: return "XDI_MagneticField";
+        case XDI_MagneticFieldCorrected: return "XDI_MagneticFieldCorrected";
+
+        case XDI_SnapshotGroup: return "XDI_SnapshotGroup";
+        case XDI_AwindaSnapshot: return "XDI_AwindaSnapshot";
+        case XDI_FullSnapshot: return "XDI_FullSnapshot";
+        case XDI_GloveSnapshotLeft: return "XDI_GloveSnapshotLeft";
+        case XDI_GloveSnapshotRight: return "XDI_GloveSnapshotRight";
+
+        case XDI_GloveDataGroup: return "XDI_GloveDataGroup";
+        case XDI_GloveDataLeft: return "XDI_GloveDataLeft";
+        case XDI_GloveDataRight: return "XDI_GloveDataRight";
+
+        case XDI_VelocityGroup: return "XDI_VelocityGroup";
+        case XDI_VelocityXYZ: return "XDI_VelocityXYZ";
+
+        case XDI_StatusGroup: return "XDI_StatusGroup";
+        case XDI_StatusByte: return "XDI_StatusByte";
+        case XDI_StatusWord: return "XDI_StatusWord";
+        case XDI_Rssi: return "XDI_Rssi";
+        case XDI_DeviceId: return "XDI_DeviceId";
+        case XDI_LocationId: return "XDI_LocationId";
+        default:    return "???";
+    }
+}
+
+bool get_xs_data_identifier_by_name(std::string name, XsDataIdentifier& identifier)
+{
+    std::map<std::string, XsDataIdentifier> name_mapping;
+
+    name_mapping["XDI_TemperatureGroup"] = XDI_TemperatureGroup;
+    name_mapping["XDI_Temperature"] = XDI_Temperature;
+
+    name_mapping["XDI_TimestampGroup"] = XDI_TimestampGroup;
+    name_mapping["XDI_UtcTime"] = XDI_UtcTime;
+    name_mapping["XDI_PacketCounter"] = XDI_PacketCounter;
+    name_mapping["XDI_Itow"] = XDI_Itow;
+    name_mapping["XDI_GnssAge"] = XDI_GnssAge;
+    name_mapping["XDI_PressureAge"] = XDI_PressureAge;
+    name_mapping["XDI_SampleTimeFine"] = XDI_SampleTimeFine;
+    name_mapping["XDI_SampleTimeCoarse"] = XDI_SampleTimeCoarse;
+    name_mapping["XDI_FrameRange"] = XDI_FrameRange;
+    name_mapping["XDI_PacketCounter8"] = XDI_PacketCounter8;
+    name_mapping["XDI_SampleTime64"] = XDI_SampleTime64;
+
+    name_mapping["XDI_OrientationGroup"] = XDI_OrientationGroup;
+    name_mapping["XDI_Quaternion"] = XDI_Quaternion;
+    name_mapping["XDI_RotationMatrix"] = XDI_RotationMatrix;
+    name_mapping["XDI_EulerAngles"] = XDI_EulerAngles;
+
+    name_mapping["XDI_PressureGroup"] = XDI_PressureGroup;
+    name_mapping["XDI_BaroPressure"] = XDI_BaroPressure;
+
+    name_mapping["XDI_AccelerationGroup"] = XDI_AccelerationGroup;
+    name_mapping["XDI_DeltaV"] = XDI_DeltaV;
+    name_mapping["XDI_Acceleration"] = XDI_Acceleration;
+    name_mapping["XDI_FreeAcceleration"] = XDI_FreeAcceleration;
+    name_mapping["XDI_AccelerationHR"] = XDI_AccelerationHR;
+
+    name_mapping["XDI_IndicationGroup"] = XDI_IndicationGroup;
+    name_mapping["XDI_TriggerIn1"] = XDI_TriggerIn1;
+    name_mapping["XDI_TriggerIn2"] = XDI_TriggerIn2;
+    name_mapping["XDI_TriggerIn3"] = XDI_TriggerIn3;
+
+    name_mapping["XDI_PositionGroup"] = XDI_PositionGroup;
+    name_mapping["XDI_AltitudeMsl"] = XDI_AltitudeMsl;
+    name_mapping["XDI_AltitudeEllipsoid"] = XDI_AltitudeEllipsoid;
+    name_mapping["XDI_PositionEcef"] = XDI_PositionEcef;
+    name_mapping["XDI_LatLon"] = XDI_LatLon;
+
+    name_mapping["XDI_GnssGroup"] = XDI_GnssGroup;
+    name_mapping["XDI_GnssPvtData"] = XDI_GnssPvtData;
+    name_mapping["XDI_GnssSatInfo"] = XDI_GnssSatInfo;
+    name_mapping["XDI_GnssPvtPulse"] = XDI_GnssPvtPulse;
+
+    name_mapping["XDI_AngularVelocityGroup"] = XDI_AngularVelocityGroup;
+    name_mapping["XDI_RateOfTurn"] = XDI_RateOfTurn;
+    name_mapping["XDI_DeltaQ"] = XDI_DeltaQ;
+    name_mapping["XDI_RateOfTurnHR"] = XDI_RateOfTurnHR;
+
+    name_mapping["XDI_RawSensorGroup"] = XDI_RawSensorGroup;
+    name_mapping["XDI_RawAccGyrMagTemp"] = XDI_RawAccGyrMagTemp;
+    name_mapping["XDI_RawGyroTemp"] = XDI_RawGyroTemp;
+    name_mapping["XDI_RawAcc"] = XDI_RawAcc;
+    name_mapping["XDI_RawGyr"] = XDI_RawGyr;
+    name_mapping["XDI_RawMag"] = XDI_RawMag;
+    name_mapping["XDI_RawDeltaQ"] = XDI_RawDeltaQ;
+    name_mapping["XDI_RawDeltaV"] = XDI_RawDeltaV;
+    name_mapping["XDI_RawBlob"] = XDI_RawBlob;
+
+    name_mapping["XDI_AnalogInGroup"] = XDI_AnalogInGroup;
+    name_mapping["XDI_AnalogIn1"] = XDI_AnalogIn1;
+    name_mapping["XDI_AnalogIn2"] = XDI_AnalogIn2;
+
+    name_mapping["XDI_MagneticGroup"] = XDI_MagneticGroup;
+    name_mapping["XDI_MagneticField"] = XDI_MagneticField;
+    name_mapping["XDI_MagneticFieldCorrected"] = XDI_MagneticFieldCorrected;
+
+    name_mapping["XDI_SnapshotGroup"] = XDI_SnapshotGroup;
+    name_mapping["XDI_AwindaSnapshot"] = XDI_AwindaSnapshot;
+    name_mapping["XDI_FullSnapshot"] = XDI_FullSnapshot;
+    name_mapping["XDI_GloveSnapshotLeft"] = XDI_GloveSnapshotLeft;
+    name_mapping["XDI_GloveSnapshotRight"] = XDI_GloveSnapshotRight;
+
+    name_mapping["XDI_GloveDataGroup"] = XDI_GloveDataGroup;
+    name_mapping["XDI_GloveDataLeft"] = XDI_GloveDataLeft;
+    name_mapping["XDI_GloveDataRight"] = XDI_GloveDataRight;
+
+    name_mapping["XDI_VelocityGroup"] = XDI_VelocityGroup;
+    name_mapping["XDI_VelocityXYZ"] = XDI_VelocityXYZ;
+
+    name_mapping["XDI_StatusGroup"] = XDI_StatusGroup;
+    name_mapping["XDI_StatusByte"] = XDI_StatusByte;
+    name_mapping["XDI_StatusWord"] = XDI_StatusWord;
+    name_mapping["XDI_Rssi"] = XDI_Rssi;
+    name_mapping["XDI_DeviceId"] = XDI_DeviceId;
+    name_mapping["XDI_LocationId"] = XDI_LocationId;
+
+    auto value = name_mapping.find(name);
+    if (value != name_mapping.end())
+    {
+        identifier = value->second;
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+bool parseConfigLine(std::string line, std::string& name, int& value)
+{
+	std::istringstream stream;
+    stream.str(line);
+	int index=0;
+	for (std::string part; std::getline(stream, part, '='); index++) {
+		// std::cout << "line PART " << part << std::endl;
+		switch (index)
+		{
+			case 0:
+			   name = part;
+			   break;
+			case 1:
+				value = std::stoi(part);
+				break;
+			default:
+				return false;
+		}
+	}
+
+    return index == 2;
+}
+

--- a/src/xdautils.cpp
+++ b/src/xdautils.cpp
@@ -1,5 +1,5 @@
-
 #include "xdautils.h"
+
 #include <map>
 #include <iostream>
 #include <sstream>
@@ -98,7 +98,7 @@ std::string get_xs_data_identifier_name(XsDataIdentifier identifier)
     }
 }
 
-bool get_xs_data_identifier_by_name(std::string name, XsDataIdentifier& identifier)
+bool get_xs_data_identifier_by_name(const std::string& name, XsDataIdentifier& identifier)
 {
     std::map<std::string, XsDataIdentifier> name_mapping;
 
@@ -202,13 +202,12 @@ bool get_xs_data_identifier_by_name(std::string name, XsDataIdentifier& identifi
     }
 }
 
-bool parseConfigLine(std::string line, std::string& name, int& value)
+bool parseConfigLine(const std::string& line, std::string& name, int& value)
 {
 	std::istringstream stream;
     stream.str(line);
 	int index=0;
 	for (std::string part; std::getline(stream, part, '='); index++) {
-		// std::cout << "line PART " << part << std::endl;
 		switch (index)
 		{
 			case 0:

--- a/src/xdautils.h
+++ b/src/xdautils.h
@@ -1,4 +1,3 @@
-
 #ifndef XDAUTILS_H
 #define XDAUTILS_H
 
@@ -6,7 +5,7 @@
 #include <string>
 
 std::string get_xs_data_identifier_name(XsDataIdentifier identifier);
-bool get_xs_data_identifier_by_name(std::string name, XsDataIdentifier& identifier);
-bool parseConfigLine(std::string line, std::string& name, int& value);
+bool get_xs_data_identifier_by_name(const std::string& name, XsDataIdentifier& identifier);
+bool parseConfigLine(const std::string& line, std::string& name, int& value);
 
 #endif

--- a/src/xdautils.h
+++ b/src/xdautils.h
@@ -1,0 +1,12 @@
+
+#ifndef XDAUTILS_H
+#define XDAUTILS_H
+
+#include <xstypes/xsdataidentifier.h>
+#include <string>
+
+std::string get_xs_data_identifier_name(XsDataIdentifier identifier);
+bool get_xs_data_identifier_by_name(std::string name, XsDataIdentifier& identifier);
+bool parseConfigLine(std::string line, std::string& name, int& value);
+
+#endif

--- a/src/xdautils_test.cpp
+++ b/src/xdautils_test.cpp
@@ -1,0 +1,57 @@
+
+
+#include "gtest/gtest.h"
+
+#include "xdautils.h"
+
+TEST(Xda, test_get_xs_data_identifier_by_name)
+{
+    XsDataIdentifier id;
+    auto result = get_xs_data_identifier_by_name("XDI_Acceleration", id);
+    ASSERT_TRUE(result);
+    ASSERT_EQ(id, XDI_Acceleration);
+}
+
+TEST(Xda, test_get_xs_data_identifier_by_name_non_existing)
+{
+    XsDataIdentifier id;
+    auto result = get_xs_data_identifier_by_name("XDI_Acceleration2", id);
+    ASSERT_FALSE(result);
+}
+
+TEST(Xda, test_get_xs_data_identifier_name)
+{
+    auto name = get_xs_data_identifier_name(XDI_Acceleration);
+    ASSERT_EQ(name, "XDI_Acceleration");
+}
+
+
+TEST(Xda, test_parse_line)
+{
+    std::string name;
+    int value;
+    auto result = parseConfigLine("XDI_Acceleration=1337", name, value);
+    ASSERT_TRUE(result);
+    ASSERT_EQ(name, "XDI_Acceleration");
+    ASSERT_EQ(value, 1337);
+}
+
+
+TEST(Xda, test_parse_line_error)
+{
+    std::string name;
+    int value;
+    auto result = parseConfigLine("XDI_Acceleration", name, value);
+    ASSERT_FALSE(result);
+}
+
+TEST(Xda, test_parse_line_error2)
+{
+    std::string name;
+    int value;
+    auto result = parseConfigLine("XDI_Acceleration=13=12", name, value);
+    ASSERT_FALSE(result);
+}
+
+
+

--- a/test/xdautils_test.cpp
+++ b/test/xdautils_test.cpp
@@ -1,5 +1,3 @@
-
-
 #include "gtest/gtest.h"
 
 #include "xdautils.h"
@@ -25,7 +23,6 @@ TEST(Xda, test_get_xs_data_identifier_name)
     ASSERT_EQ(name, "XDI_Acceleration");
 }
 
-
 TEST(Xda, test_parse_line)
 {
     std::string name;
@@ -35,7 +32,6 @@ TEST(Xda, test_parse_line)
     ASSERT_EQ(name, "XDI_Acceleration");
     ASSERT_EQ(value, 1337);
 }
-
 
 TEST(Xda, test_parse_line_error)
 {
@@ -52,6 +48,3 @@ TEST(Xda, test_parse_line_error2)
     auto result = parseConfigLine("XDI_Acceleration=13=12", name, value);
     ASSERT_FALSE(result);
 }
-
-
-


### PR DESCRIPTION
In cases where the MTi is build in and cannot be accessed easily, we want to be able to change certain settings via parameters. This series of patches adds the abilities to configure:
* baudrate
* filter profile
* output quantities
* rotation matrices

(this time against the galactic branch as intended)