### PR TITLE
Subscribe and use RTCM correction messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(tf2_ros REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(mavros_msgs REQUIRED)
 
 ###########
 ## Build ##
@@ -40,6 +41,7 @@ ament_target_dependencies(xsens_mti_node
   std_msgs
   geometry_msgs
   sensor_msgs
+  mavros_msgs
 )
 
 target_link_libraries(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(std_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(mavros_msgs REQUIRED)
+find_package(diagnostic_msgs REQUIRED)
 
 ###########
 ## Build ##
@@ -42,6 +43,7 @@ ament_target_dependencies(xsens_mti_node
   geometry_msgs
   sensor_msgs
   mavros_msgs
+  diagnostic_msgs
 )
 
 target_link_libraries(

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>diagnostic_msgs</build_depend>
   <build_export_depend>rclcpp</build_export_depend>
   <build_export_depend>tf2</build_export_depend>
   <build_export_depend>tf2_ros</build_export_depend>

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>mavros_msgs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,11 +62,13 @@
 #include <rclcpp/rclcpp.hpp>
 #include "xdainterface.h"
 
+#include <mavros_msgs/msg/rtcm.h>
 #include <iostream>
 #include <stdexcept>
 #include <string>
 
 using std::chrono::milliseconds;
+using std::placeholders::_1;
 
 Journaller *gJournal = 0;
 
@@ -86,6 +88,10 @@ int main(int argc, char *argv[])
 
 	if (!xdaInterface->prepare())
 		return -1;
+
+	rclcpp::Subscription<mavros_msgs::msg::RTCM>::SharedPtr subscription =
+		xdaInterface->create_subscription<mavros_msgs::msg::RTCM>(
+			"/rtcm", 10, std::bind(&XdaInterface::rtcmCallback, xdaInterface, _1));
 
 	while (rclcpp::ok())
 	{

--- a/src/messagepublishers/statuspublisher.h
+++ b/src/messagepublishers/statuspublisher.h
@@ -1,0 +1,90 @@
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//  Copyright (c) 2003-2020 Xsens Technologies B.V. or subsidiaries worldwide.
+//  All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  
+//  1.	Redistributions of source code must retain the above copyright notice,
+//  	this list of conditions, and the following disclaimer.
+//  
+//  2.	Redistributions in binary form must reproduce the above copyright notice,
+//  	this list of conditions, and the following disclaimer in the documentation
+//  	and/or other materials provided with the distribution.
+//  
+//  3.	Neither the names of the copyright holders nor the names of their contributors
+//  	may be used to endorse or promote products derived from this software without
+//  	specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+//  THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+//  OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+//  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY OR
+//  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.THE LAWS OF THE NETHERLANDS 
+//  SHALL BE EXCLUSIVELY APPLICABLE AND ANY DISPUTES SHALL BE FINALLY SETTLED UNDER THE RULES 
+//  OF ARBITRATION OF THE INTERNATIONAL CHAMBER OF COMMERCE IN THE HAGUE BY ONE OR MORE 
+//  ARBITRATORS APPOINTED IN ACCORDANCE WITH SAID RULES.
+//  
+
+#ifndef STATUSPUBLISHER_H
+#define STATUSPUBLISHER_H
+
+#include "packetcallback.h"
+#include <diagnostic_msgs/msg/key_value.hpp>
+#include <bitset>
+
+struct StatusPublisher : public PacketCallback
+{
+    rclcpp::Publisher<diagnostic_msgs::msg::KeyValue>::SharedPtr pub;
+    std::string frame_id = DEFAULT_FRAME_ID;
+
+    StatusPublisher(rclcpp::Node &node)
+    {
+        int pub_queue_size = 5;
+        node.get_parameter("publisher_queue_size", pub_queue_size);
+        pub = node.create_publisher<diagnostic_msgs::msg::KeyValue>("status", pub_queue_size);
+        node.get_parameter("frame_id", frame_id);
+    }
+    
+    void operator()(const XsDataPacket &packet, rclcpp::Time timestamp)
+    {
+        if (packet.containsStatus())
+        {
+            diagnostic_msgs::msg::KeyValue msg;
+
+            msg.key = "StatusWord";
+            msg.value = std::bitset<32>(packet.status()).to_string();
+            pub->publish(msg);
+        }
+    }
+};
+
+#endif

--- a/src/xdainterface.cpp
+++ b/src/xdainterface.cpp
@@ -84,6 +84,7 @@
 #include "messagepublishers/velocityincrementpublisher.h"
 #include "messagepublishers/positionllapublisher.h"
 #include "messagepublishers/velocitypublisher.h"
+#include "messagepublishers/statuspublisher.h"
 
 XdaInterface::XdaInterface(const std::string &node_name, const rclcpp::NodeOptions &options)
 	: Node(node_name, options)
@@ -184,6 +185,10 @@ void XdaInterface::registerPublishers()
 	if (get_parameter("pub_velocity", should_publish) && should_publish)
 	{
 		registerCallback(new VelocityPublisher(node));
+	}
+	if (get_parameter("pub_status", should_publish) && should_publish)
+	{
+		registerCallback(new StatusPublisher(node));
 	}
 }
 
@@ -365,6 +370,7 @@ void XdaInterface::declareCommonParameters()
 	declare_parameter("pub_transform", should_publish);
 	declare_parameter("pub_positionLLA", should_publish);
 	declare_parameter("pub_velocity", should_publish);
+	declare_parameter("pub_status", should_publish);
 
 	declare_parameter("scan_for_devices", true);
 	declare_parameter("device_id", "");

--- a/src/xdainterface.cpp
+++ b/src/xdainterface.cpp
@@ -64,6 +64,8 @@
 #include <xscontroller/xsscanner.h>
 #include <xscontroller/xscontrol_def.h>
 #include <xscontroller/xsdevice_def.h>
+#include <mavros_msgs/msg/rtcm.h>
+
 
 #include "messagepublishers/packetcallback.h"
 #include "messagepublishers/accelerationpublisher.h"
@@ -302,6 +304,17 @@ bool XdaInterface::prepare()
 	}
 
 	return true;
+}
+
+void XdaInterface::rtcmCallback(const mavros_msgs::msg::RTCM::SharedPtr msg)
+{
+	RCLCPP_INFO(this->get_logger(), "RTCM received at [%d]", msg->header.stamp.sec);
+	XsMessage rtcm(XMID_ForwardGnssData);
+	uint16_t rtcmMessageLength = (const uint16_t)msg->data.size();
+	rtcm.setDataBuffer((const uint8_t*)&msg->data[0], rtcmMessageLength, 0);
+
+	XsMessage rcv;
+	m_device->sendCustomMessage(rtcm, false, rcv, 0);
 }
 
 void XdaInterface::close()

--- a/src/xdainterface.h
+++ b/src/xdainterface.h
@@ -63,6 +63,7 @@
 #define XDAINTERFACE_H
 
 #include <rclcpp/rclcpp.hpp>
+#include <mavros_msgs/msg/rtcm.hpp>
 
 #include "xdacallback.h"
 #include <xstypes/xsportinfo.h>
@@ -83,6 +84,7 @@ public:
 
 	void spinFor(std::chrono::milliseconds timeout);
 	void registerPublishers();
+	void rtcmCallback(const mavros_msgs::msg::RTCM::SharedPtr msg);
 
 	bool connectDevice();
 	bool prepare();


### PR DESCRIPTION
This implements the subscription of RTCM correction messages. These messages are sent to the XSens device. Additionally, the device status is published.

Based on ROS1 implementation available at https://xsenstechnologies.force.com/knowledgebase/s/article/Using-an-NTRIP-client-with-the-Xsens-ROS-driver?language=en_US

Requires ros-[ROSDISTRIBUTION]-mavros-msgs package

Status publisher requires ros-[ROSDISTRIBUTION]-diagnostic_msgs package

An NTRIP client for ROS2 is available here: https://github.com/nerovalerius/ntrip_client_ros2